### PR TITLE
Increase cmd buffer size

### DIFF
--- a/source/buspirateNG.h
+++ b/source/buspirateNG.h
@@ -1,7 +1,7 @@
 // global config file
 
 // UI stuff
-#define CMDBUFFSIZE	512		// must be power of 2
+#define CMDBUFFSIZE	16384		// must be power of 2
 
 // USB shit :/
 


### PR DESCRIPTION
This chip has 20KB ram, mostly unused, 512bytes is ok, but we could send much larger payloads.
Increase buffer size to 16KB, still ~500 bytes free!